### PR TITLE
Implementation plan: Allow cancellation of prediction while running prompt

### DIFF
--- a/inference/server/oasst_inference_server/routes/chats.py
+++ b/inference/server/oasst_inference_server/routes/chats.py
@@ -266,6 +266,9 @@ async def message_events(
 
             logger.info(f"Finished streaming {chat_id}")
         except Exception:
+            # TODO: catch asyncio.CancelledError separately; it indicates that the user is no longer interested in receiving the response
+            # Make sure to close the stream from the worker server so that the generation is also stopped.
+            # Possibly set the status of the message in the database to cancelled.
             logger.exception(f"Error streaming {chat_id}")
             raise
         finally:


### PR DESCRIPTION
Implementation plan for the backend part of [Allow cancellation of prediction while running prompt](https://github.com/LAION-AI/Open-Assistant/issues/2815).

Planned changes: cancel prediction when the event source is closed in the UI.

Necessary steps:
- in the `oasst_inference_server` that communicates directly with the UI, catch the `asyncio.CancelledError` that indicates that the event stream was closed by the client (see example in [documentation of sse-starlette](https://github.com/sysid/sse-starlette)) - we will use this to indicate that the generation should be cancelled
- propagate the cancellation by closing the stream to the worker defined in `basic_hf_server.py`
- also catch the `CancelledError` in `basic_hf_server.py`; when this happens, set a flag that indicates that the inference should be stopped
- add a stopping criterion to the model that checks if the flag is set

Check the diff in this MR for the exact lines where I would change something.